### PR TITLE
使index_cn.html与index.html保持一致。

### DIFF
--- a/index_cn.html
+++ b/index_cn.html
@@ -38,7 +38,7 @@
     <li><a href="http://wiki.nginx.org/HttpLuaModule">动态脚本语言Lua</a>支持。扩展功能非常高效简单；</li>
     <li><a href="document_cn/http_log_cn.html">支持管道（pipe）和syslog（本地和远端）形式的日志以及日志抽样</a>；</li>
     <li><a href="document_cn/http_concat_cn.html">组合多个CSS、JavaScript文件的访问请求变成一个请求</a>；</li>
-    <li><a href="document_cn/http_trim_filter_cn.html">自动去除空白字符和注释</a>从而减小页面的体积</li>
+    <li><a href="document_cn/http_trim_filter_cn.html">自动去除空白字符和注释</a>从而减小页面的体积；</li>
     <li><a href="document_cn/http_upstream_check_cn.html">可以对后端的服务器进行主动式健康检查</a>；</li>
     <li>自动根据CPU数目设置进程个数和绑定CPU亲缘性；</li>
     <li><a href="document_cn/http_sysguard_cn.html">监控系统的负载和资源占用从而对系统进行保护</a>；</li>


### PR DESCRIPTION
index_cn.html里对upstream check的介绍放到独立地方。
“根据服务器状态自动上线下线”这个功能我没找到应该是属于那一个模块的。 貌似upstream check模块没有这个功能？
于是把它删除了。。。
